### PR TITLE
Update docs to conform with command

### DIFF
--- a/cmd/secrets/README.md
+++ b/cmd/secrets/README.md
@@ -39,7 +39,7 @@ secrets -x label
 To change the password for *label* (password set overwriting):
 
 ```
-secrets -s -o label
+secrets -s -w label
 ```
 
 To remove the password for *label* (password remove):


### PR DESCRIPTION
The secrets command takes the '-w' (overWrite) flag when calling with '-s'.  This allows you to update a stored secret.  The existing doc has two examples of this, one using the correct flag '-w' and one using a flag that doesn't seem to exist '-o'.  This simple diff just updates the doc to match the code.
