### PR TITLE
Added Scrypt cost arg and store init.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@
 /cmd/secret-sync-server/*.db
 /cmd/secret-sync-server/*.key
 /cmd/secret-sync-server/*.pem
-
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /cmd/secret-sync-server/*.db
 /cmd/secret-sync-server/*.key
 /cmd/secret-sync-server/*.pem
+
+*.swp

--- a/cmd/journal/README.md
+++ b/cmd/journal/README.md
@@ -18,6 +18,25 @@ Entries are displayed in plain text with no formatting; the output
 could be piped elsewhere to display the entry with formatting, but I
 don't find this useful and therefore haven't put it in.
 
+To create a new password store *(defaults to `~/.cu_journal`)*:
+
+```
+journal -init
+```
+
+To create a new journal store specific file:
+```
+journal -init -f ~/.myjournal
+```
+
+To create a new journal store with interactive scrypt work factors:
+```
+journal -init -i
+```
+*If you specify interactive you'll need to specify it
+for all other crud operations to the store.*
+**This defaults to standard mode**
+
 Writing an entry:
 
 ```

--- a/cmd/otpc/otpc.go
+++ b/cmd/otpc/otpc.go
@@ -32,8 +32,30 @@ var commandSet = map[string]command{
 	"qr":    {false, 2, showQR, []string{"label", "filename"}},
 }
 
+// These constants are used to identify various OTP algorithms
+const (
+	Unknown = 0
+	HOTP    = iota + 1
+	TOTP
+	GoogleTOTP
+)
+
+func writeStore(ps *store.SecretStore, path string, m secret.ScryptMode) bool {
+	fileData, ok := store.MarshalSecretStore(ps, m)
+	if !ok {
+		return false
+	}
+
+	err := util.WriteFile(fileData, path)
+	if err != nil {
+		util.Errorf("Write failed: %v", err)
+		return false
+	}
+	return true
+}
+
 func loadStore(path string, m secret.ScryptMode) *store.SecretStore {
-	passphrase, err := util.PassPrompt("Two-factor store passphrase> ")
+	passphrase, err := util.PassPrompt("Secrets passphrase> ")
 	if err != nil {
 		util.Errorf("Failed to read passphrase: %v", err)
 		return nil
@@ -54,54 +76,39 @@ func loadStore(path string, m secret.ScryptMode) *store.SecretStore {
 		}
 		return passwords
 	}
-	return newStore(path, passphrase, m)
+	util.Errorf("could not find %s", path)
+	return nil
 }
 
-func newStore(path string, passphrase []byte, m secret.ScryptMode) *store.SecretStore {
+func initStore(path string, m secret.ScryptMode) error {
+	passphrase, err := util.PassPrompt("Secrets passphrase> ")
+	if err != nil {
+		util.Errorf("Failed to read passphrase: %v", err)
+		return err
+	}
 	defer util.Zero(passphrase)
 	passwords := store.NewSecretStore(passphrase)
 	if passwords == nil {
-		return nil
+		return fmt.Errorf("failed to create store")
 	}
 
+	fmt.Println("creating store...")
 	fileData, ok := store.MarshalSecretStore(passwords, m)
 	if !ok {
-		return nil
+		return fmt.Errorf("failed to marshal store")
 	}
 
-	err := util.WriteFile(fileData, path)
+	err = util.WriteFile(fileData, path)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	passwords, ok = store.UnmarshalSecretStore(fileData, passphrase, m)
 	if !ok {
-		return nil
+		err = fmt.Errorf("failed to unmarshal store")
 	}
-	return passwords
+	return err
 }
-
-func writeStore(ps *store.SecretStore, path string, m secret.ScryptMode) bool {
-	fileData, ok := store.MarshalSecretStore(ps, m)
-	if !ok {
-		return false
-	}
-
-	err := util.WriteFile(fileData, path)
-	if err != nil {
-		util.Errorf("Write failed: %v", err)
-		return false
-	}
-	return true
-}
-
-// These constants are used to identify various OTP algorithms
-const (
-	Unknown = 0
-	HOTP    = iota + 1
-	TOTP
-	GoogleTOTP
-)
 
 func parseOTPKind(t string) int {
 	t = strings.ToLower(t)
@@ -394,6 +401,7 @@ func showSecret(ps *store.SecretStore, cfg *config) error {
 
 func main() {
 	baseFile := filepath.Join(os.Getenv("HOME"), ".otpc.db")
+	doInit := flag.Bool("init", false, "initialize a new store")
 	doStore := flag.Bool("s", false, "store a new two-factor token")
 	storePath := flag.String("f", baseFile, "path to password store")
 	otpKind := flag.String("t", "", "OTP type (TOTP, HOTP, GOOGLE)")
@@ -419,6 +427,14 @@ func main() {
 
 	var cmd command
 	switch {
+	case *doInit:
+		cmd = commandSet["init"]
+		err := initStore(*storePath, scryptMode)
+		if err != nil {
+			util.Errorf("Failed: %v", err)
+			os.Exit(1)
+		}
+		return
 	case *doStore:
 		cmd = commandSet["store"]
 	case *doQR:

--- a/cmd/secrets/README.md
+++ b/cmd/secrets/README.md
@@ -18,6 +18,25 @@ as possible).
 
 ## Usage (using a password manager example):
 
+To create a new password store *(defaults to `~/.secrets.db`)*:
+
+```
+secrets -init
+```
+
+To create a new password store specific file:
+```
+secrets -init -f ~/.mysecrets
+```
+
+To create a new password store with a specific scrypt value:
+```
+secrets -init -t 1
+```
+*If you choose a non-default value you'll need to use
+the `-t` argument for all other crud operations to the store.*  
+**Valid values are `1, 2, 3, 4`, with `4` being the default/strongest.*
+
 To add a new password (password set):
 
 ```

--- a/cmd/secrets/README.md
+++ b/cmd/secrets/README.md
@@ -2,7 +2,7 @@
 ### a command line secrets manager
 
 This a personal secrets manager, written for me, that operates on the
-command line. It wrote it primarily to store and retrieve passwords
+command line. I wrote it primarily to store and retrieve passwords
 and optional metadata, but it can be used to store almost any kind of
 secret. It is also a general utility for interacting with secret
 stores built using the

--- a/cmd/secrets/README.md
+++ b/cmd/secrets/README.md
@@ -29,13 +29,13 @@ To create a new password store specific file:
 secrets -init -f ~/.mysecrets
 ```
 
-To create a new password store with a specific scrypt value:
+To create a new password store with interactive scrypt work factors:
 ```
-secrets -init -t 1
+secrets -init -i
 ```
-*If you choose a non-default value you'll need to use
-the `-t` argument for all other crud operations to the store.*  
-**Valid values are `1, 2, 3, 4`, with `4` being the default/strongest.*
+*If you specify interactive you'll need to specify it
+for all other crud operations to the store.*
+**This defaults to standard mode**
 
 To add a new password (password set):
 

--- a/cmd/secrets/secrets.go
+++ b/cmd/secrets/secrets.go
@@ -12,10 +12,8 @@ import (
 	"time"
 
 	"github.com/gokyle/readpass"
-	//"github.com/kisom/cryptutils/common/secret"
-	"github.com/juztin/cryptutils/common/secret"
-	//"github.com/kisom/cryptutils/common/store"
-	"github.com/juztin/cryptutils/common/store"
+	"github.com/kisom/cryptutils/common/secret"
+	"github.com/kisom/cryptutils/common/store"
 	"github.com/kisom/cryptutils/common/util"
 )
 

--- a/common/store/secretstore.go
+++ b/common/store/secretstore.go
@@ -4,8 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	//"github.com/kisom/cryptutils/common/secret"
-	"github.com/juztin/cryptutils/common/secret"
+	"github.com/kisom/cryptutils/common/secret"
 	"github.com/kisom/cryptutils/common/util"
 )
 
@@ -203,7 +202,6 @@ func MarshalSecretStore(s *SecretStore, p secret.ScryptParams) ([]byte, bool) {
 		return nil, false
 	}
 
-	//key := secret.DeriveKey(s.passphrase, salt)
 	key := secret.DeriveKeyStrength(s.passphrase, salt, p)
 	if key == nil {
 		return nil, false
@@ -229,7 +227,6 @@ func UnmarshalSecretStore(in, passphrase []byte, p secret.ScryptParams) (*Secret
 
 	salt := in[:saltSize]
 	enc := in[saltSize:]
-	//key := secret.DeriveKey(passphrase, salt, p)
 	key := secret.DeriveKeyStrength(passphrase, salt, p)
 	if key == nil {
 		return nil, false

--- a/common/store/secretstore.go
+++ b/common/store/secretstore.go
@@ -186,7 +186,7 @@ func (s *SecretStore) Merge(other *SecretStore) []string {
 
 // MarshalSecretStore serialises and encrypts the data store to a byte
 // slice suitable for writing to disk.
-func MarshalSecretStore(s *SecretStore, p secret.ScryptParams) ([]byte, bool) {
+func MarshalSecretStore(s *SecretStore, m secret.ScryptMode) ([]byte, bool) {
 	if !s.Valid() {
 		return nil, false
 	}
@@ -202,7 +202,7 @@ func MarshalSecretStore(s *SecretStore, p secret.ScryptParams) ([]byte, bool) {
 		return nil, false
 	}
 
-	key := secret.DeriveKeyStrength(s.passphrase, salt, p)
+	key := secret.DeriveKeyStrength(s.passphrase, salt, m)
 	if key == nil {
 		return nil, false
 	}
@@ -220,14 +220,14 @@ func MarshalSecretStore(s *SecretStore, p secret.ScryptParams) ([]byte, bool) {
 
 // UnmarshalSecretStore decrypts and parses the secret store contained
 // in the input byte slice.
-func UnmarshalSecretStore(in, passphrase []byte, p secret.ScryptParams) (*SecretStore, bool) {
+func UnmarshalSecretStore(in, passphrase []byte, m secret.ScryptMode) (*SecretStore, bool) {
 	if len(in) < saltSize {
 		return nil, false
 	}
 
 	salt := in[:saltSize]
 	enc := in[saltSize:]
-	key := secret.DeriveKeyStrength(passphrase, salt, p)
+	key := secret.DeriveKeyStrength(passphrase, salt, m)
 	if key == nil {
 		return nil, false
 	}

--- a/common/store/secretstore.go
+++ b/common/store/secretstore.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/kisom/cryptutils/common/secret"
+	//"github.com/kisom/cryptutils/common/secret"
+	"github.com/juztin/cryptutils/common/secret"
 	"github.com/kisom/cryptutils/common/util"
 )
 
@@ -186,7 +187,7 @@ func (s *SecretStore) Merge(other *SecretStore) []string {
 
 // MarshalSecretStore serialises and encrypts the data store to a byte
 // slice suitable for writing to disk.
-func MarshalSecretStore(s *SecretStore) ([]byte, bool) {
+func MarshalSecretStore(s *SecretStore, p secret.ScryptParams) ([]byte, bool) {
 	if !s.Valid() {
 		return nil, false
 	}
@@ -202,7 +203,8 @@ func MarshalSecretStore(s *SecretStore) ([]byte, bool) {
 		return nil, false
 	}
 
-	key := secret.DeriveKey(s.passphrase, salt)
+	//key := secret.DeriveKey(s.passphrase, salt)
+	key := secret.DeriveKeyStrength(s.passphrase, salt, p)
 	if key == nil {
 		return nil, false
 	}
@@ -220,14 +222,15 @@ func MarshalSecretStore(s *SecretStore) ([]byte, bool) {
 
 // UnmarshalSecretStore decrypts and parses the secret store contained
 // in the input byte slice.
-func UnmarshalSecretStore(in, passphrase []byte) (*SecretStore, bool) {
+func UnmarshalSecretStore(in, passphrase []byte, p secret.ScryptParams) (*SecretStore, bool) {
 	if len(in) < saltSize {
 		return nil, false
 	}
 
 	salt := in[:saltSize]
 	enc := in[saltSize:]
-	key := secret.DeriveKey(passphrase, salt)
+	//key := secret.DeriveKey(passphrase, salt, p)
+	key := secret.DeriveKeyStrength(passphrase, salt, p)
 	if key == nil {
 		return nil, false
 	}


### PR DESCRIPTION
Hey Kyle,

Here's the two changes:
1. Ability to specify the scrypt cost factor. _(1-4, with 4 being the highest/default and the original value)_
   This was nice for the not so critical secrets, especially on my ARM dev boards.
2. Added an `init` arg that initializes/creates a store. I found myself fat-fingering the `secrets.db` path occasionally and wanted to avoid potentially creating an additional store.

Lemme know what you think.
Thanks =)
