### PR TITLE
Add secretscli, an interactive client.

### DIFF
--- a/cmd/secretscli/README.md
+++ b/cmd/secretscli/README.md
@@ -49,3 +49,6 @@ There's a help system too; enter the "help" command to see all the
 supported commands.
 
 The UI is admittedly weak for other people, but this is what I wanted.
+
+The tool will timeout after an adjustable period of time (5 minutes),
+relocking the secret store and exiting.

--- a/cmd/secretscli/README.md
+++ b/cmd/secretscli/README.md
@@ -1,0 +1,51 @@
+## secretscli
+### An interactive secrets client
+
+This is an interactive secrets manager that acts on the same secret
+stores used by the other tools in this collection. It offers a subset
+of the functions provided by the `secrets` utility, but does so
+interactively. To whit:
+
+```
+~/src/github.com/kisom/cryptutils/cmd/secretscli
+(0) <straka:kyle> $ secrets -f secrets.db -i -init 
+Secrets passphrase> 
+creating store...
+~/src/github.com/kisom/cryptutils/cmd/secretscli
+(0) <straka:kyle> $ secretscli -f secrets.db -i 
+Passphrase to unlock secrets.db: 
+secrets.db command> list
+Key store: 0 keys
+secrets.db command> store mail db
+[+] Storing secret for mail
+New password: 
+[+] Storing secret for db
+New password: 
+secrets.db command> wmeta db
+Enter metadata; use an empty line to indicate that you are done.
+key = value: host = db.local
+key = value: user = db-user
+key = value: name = blatdb 
+key = value: 
+secrets.db command> wmeta db 
+Enter metadata; use an empty line to indicate that you are done.
+key = value: name = blat-db
+Note: replacing previous value of 'blatdb'
+key = value: 
+secrets.db command> store db
+[+] Storing secret for db
+db exists. Overwrite secret (y/n)? n
+Not overwriting.
+secrets.db command> store db
+[+] Storing secret for db
+db exists. Overwrite secret (y/n)? y
+New password: 
+secrets.db command> [+] storing secret store...
+~/src/github.com/kisom/cryptutils/cmd/secretscli
+(0) <straka:kyle> $ 
+```
+
+There's a help system too; enter the "help" command to see all the
+supported commands.
+
+The UI is admittedly weak for other people, but this is what I wanted.

--- a/cmd/secretscli/commands.go
+++ b/cmd/secretscli/commands.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gokyle/readpass"
+	"github.com/kisom/cryptutils/common/store"
+	"github.com/kisom/cryptutils/common/util"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var dispatch = map[string]func(args []string) error{
+	"clear":   clearTerm,
+	"help":    help,
+	"list":    listSecrets,
+	"quit":    quitProgram,
+	"passwd":  passwd,
+	"rmeta":   readMeta,
+	"show":    showSecret,
+	"showhex": showSecretHex,
+	"store":   storeSecret,
+	"wmeta":   writeMeta,
+	"write":   cmdWriteStore,
+}
+
+func quitProgram(args []string) error {
+	shutdown()
+	os.Exit(0)
+	return nil /* yes, this is required */
+}
+
+func clearTerm(args []string) error {
+	fmt.Println("\033[H\033[2J")
+	return nil
+}
+
+func dumpKeys(keys []string) {
+	for i := range keys {
+		fmt.Println(keys[i])
+	}
+}
+
+func passwd(args []string) error {
+	newPass, err := util.PassPrompt("New password: ")
+	if err != nil {
+		return err
+	}
+
+	confirmPass, err := util.PassPrompt("Confirm: ")
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(confirmPass, newPass) {
+		return errors.New("passwords don't match")
+	}
+
+	util.Zero(confirmPass)
+
+	session.Store.ChangePassword(newPass)
+	fmt.Println("[+] Password updated.")
+	return nil
+}
+
+func dumpFmtKeys(keys []string, w int) {
+	// Two columns, indent a tab.
+	split := w/2 - 8
+	first := fmt.Sprintf("\t%%-%ds", split)
+
+	for i := 1; i < len(keys)+1; i++ {
+		if (i % 2) == 1 {
+			fmt.Printf(first, keys[i-1])
+		} else {
+			fmt.Println(keys[i-1])
+		}
+	}
+	if len(keys)%2 == 1 {
+		fmt.Printf("\n")
+	}
+}
+
+func listSecrets(args []string) error {
+	var keys = make([]string, 0, len(session.Store.Store))
+
+	w, _, err := terminal.GetSize(1)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %v\n", err)
+		w = 80
+	}
+
+	var max int
+	for label := range session.Store.Store {
+		if len(args) > 0 {
+			var match bool
+			for _, pat := range args {
+				if strings.Contains(label, pat) {
+					match = true
+					break
+				}
+			}
+
+			if !match {
+				continue
+			}
+		}
+
+		keys = append(keys, label)
+		if len(label) > max {
+			max = len(label)
+		}
+	}
+
+	fmt.Printf("Key store: %d keys\n", len(keys))
+	sort.Strings(keys)
+	if max > w {
+		dumpKeys(keys)
+	} else {
+		dumpFmtKeys(keys, w)
+	}
+	return nil
+}
+
+func showSecret(args []string) error {
+	switch {
+	case len(args) == 0:
+		return errors.New("No labels specified.")
+	case len(args) == 1:
+		r, ok := session.Store.Store[args[0]]
+		if !ok {
+			fmt.Println("[!]", args[0], "not found.")
+		} else {
+			fmt.Println(string(r.Secret))
+		}
+	default:
+		for _, label := range args {
+			r, ok := session.Store.Store[label]
+			if !ok {
+				fmt.Println("[!]", label, "not found.")
+			} else {
+				fmt.Printf("%s: %s\n", label, string(r.Secret))
+			}
+		}
+	}
+	return nil
+}
+
+func showSecretHex(args []string) error {
+	switch {
+	case len(args) == 0:
+		return errors.New("no labels specified.")
+	case len(args) == 1:
+		r, ok := session.Store.Store[args[0]]
+		if !ok {
+			fmt.Println("[!]", args[0], "not found.")
+		} else {
+			fmt.Printf("%x\n", r.Secret)
+		}
+	default:
+		for _, label := range args {
+			r, ok := session.Store.Store[label]
+			if !ok {
+				fmt.Println("[!]", label, "not found.")
+			} else {
+				fmt.Printf("%s: %x\n", label, r.Secret)
+			}
+		}
+	}
+	return nil
+}
+
+const timeFormat = "2006-01-02 15:04:05 MST"
+
+func readMeta(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no labels specified.")
+	}
+
+	for _, label := range args {
+		r, ok := session.Store.Store[label]
+		if !ok {
+			fmt.Printf("[!] %s not found.\n", label)
+			continue
+		}
+
+		fmt.Printf("Record: %s\n", label)
+		fmt.Printf("\tLast modification: %s (timestamp %d)\n",
+			time.Unix(r.Timestamp, 0).Format(timeFormat),
+			r.Timestamp)
+		if len(r.Metadata) > 0 {
+			fmt.Println("\tMetadata:")
+			for k, v := range r.Metadata {
+				fmt.Printf("\t\t%s: %s\n", k, v)
+			}
+		}
+	}
+	return nil
+}
+
+func writeMeta(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no label specified")
+	} else if len(args) > 1 {
+		return errors.New("only one label may be specified")
+	}
+
+	label := args[0]
+	r, ok := session.Store.Store[label]
+	if !ok {
+		return errors.New("no such record")
+	}
+
+	if r.Metadata == nil {
+		r.Metadata = map[string][]byte{}
+	}
+
+	fmt.Println("Enter metadata; use an empty line to indicate that you are done.")
+	for {
+		line, err := util.ReadLine("key = value: ")
+		if err != nil {
+			return err
+		} else if line == "" {
+			break
+		}
+
+		meta := strings.SplitN(line, "=", 2)
+		if len(meta) < 2 {
+			util.Errorf("Metadata should be in the form 'key=value'")
+			continue
+		}
+
+		key := strings.TrimSpace(meta[0])
+		val := strings.TrimSpace(meta[1])
+
+		if prev, ok := r.Metadata[key]; ok {
+			fmt.Printf("Note: replacing previous value of '%s'\n", string(prev))
+		}
+
+		r.Metadata[key] = []byte(val)
+	}
+	r.Timestamp = time.Now().Unix()
+	session.Store.Timestamp = r.Timestamp
+	session.Store.Store[label] = r
+	session.Dirty = true
+	return nil
+}
+
+func cmdWriteStore(args []string) error {
+	if len(args) != 0 {
+		return errors.New("write takes no arguments")
+	}
+
+	if !writeStore() {
+		return errors.New("failed to write store")
+	}
+
+	return nil
+}
+
+func storeSingleSecret(label string) error {
+	r, ok := session.Store.Store[label]
+	if ok {
+		answer, err := util.ReadLine(label + " exists. Overwrite secret (y/n)? ")
+		if err != nil {
+			return err
+		}
+		answer = strings.ToLower(answer)
+		if answer != "y" && answer != "yes" {
+			fmt.Println("Not overwriting.")
+			return nil
+		}
+	} else {
+		r = new(store.SecretRecord)
+	}
+
+	password, err := readpass.PasswordPromptBytes("New password: ")
+	if err != nil {
+		return err
+	} else if len(password) == 0 {
+		return errors.New("no password entered")
+	}
+
+	util.Zero(r.Secret)
+	r.Secret = password
+	r.Timestamp = time.Now().Unix()
+	session.Store.Timestamp = r.Timestamp
+	session.Store.Store[label] = r
+	session.Dirty = true
+	return nil
+}
+
+func storeSecret(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no labels provided")
+	}
+
+	for i, label := range args {
+		fmt.Println("[+] Storing secret for", label)
+		err := storeSingleSecret(label)
+		if err != nil {
+			if i > 0 {
+				writeStore()
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/secretscli/help.go
+++ b/cmd/secretscli/help.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+type cmdHelp struct {
+	Args string
+	Desc string
+	OLD  string /* one line description */
+}
+
+var helpTable = map[string]*cmdHelp{
+	"clear": {
+		Args: "none",
+		Desc: `
+
+	Clear the screen using an ANSI escape code. This may not work
+	in all terminals.
+`,
+		OLD: "attempt to clear the display",
+	},
+	"help": {
+		Args: "optional: command names",
+		Desc: `
+
+	Show help messages. If arguments are provided, show the
+	full help message for the first argument.
+`,
+		OLD: "print usage information",
+	},
+	"list": {
+		Args: "optional: substrings to search for",
+		Desc: `
+
+	List the secrets in the store. If arguments are provided,
+	they will be used to match labels: a label will be included
+	in the list if any of the argumnts appear as substrings in
+	the label.
+`,
+		OLD: "list the labels in the store",
+	},
+	"passwd": {
+		Args: "none",
+		Desc: `
+
+	Change the password on the store. Accepts no arguments.
+`,
+		OLD: "change the store's passphrase",
+	},
+	"quit": {
+		Args: "none",
+		Desc: `
+
+	Write the store to disk if it has been modified and exit. This
+	may also be done with C-d.
+`,
+		OLD: "exit the program",
+	},
+	"rmeta": {
+		Args: "required: one or more labels",
+		Desc: `
+
+	Read metadata from the listed labels. Requires at least one
+	label to be provided.
+`,
+		OLD: "display record metadata",
+	},
+	"show": {
+		Args: "required: one or more labels",
+		Desc: `
+
+	Print a secret's raw bytes to console. This is useful if the
+	secret is textual (e.g. a passphrase); for binary data, see
+	'showhex'. If more than one label is specified, the passwords
+	will be printed with their label.
+`,
+		OLD: "show secrets as text",
+	},
+	"showhex": {
+		Args: "required: one or more labels",
+		Desc: `
+
+	Print a hex-encoded secret to console. This is useful if the
+	secret contains binary data; for textual secrets, see
+	'show'. If more than one label is specified, the passwords
+	will be printed with their label.
+`,
+		OLD: "show secrets as hex-encoded",
+	},
+	"store": {
+		Args: "required: one or more labels",
+		Desc: `
+
+	Store a new passphrase for each of the labels specified. If the
+	label already exists, the user will be prompted whether or not
+	they wish to proceed.
+`,
+		OLD: "store secrets",
+	},
+	"wmeta": {
+		Args: "required: a single label",
+		Desc: `
+
+	Write metadata to the label; only one label may be
+	specified. For metadata keys that replace old values, the
+	previous value will be displayed and the overwrite will be
+	noted.
+`,
+		OLD: "write metadata",
+	},
+	"write": {
+		Args: "none",
+		Desc: `
+
+	Write the store to disk. Note that this will be done
+	automatically when the program exits, as well.
+`,
+		OLD: "write the store to disk",
+	},
+}
+
+var commandList []string
+
+func init() {
+	commandList = make([]string, 0, len(dispatch))
+
+	for cmd := range dispatch {
+		if _, ok := helpTable[cmd]; ok {
+			commandList = append(commandList, cmd)
+		} else {
+			fmt.Printf("[!] Warning: command %s isn't documented. This is a bug!\n", cmd)
+		}
+	}
+	sort.Strings(commandList)
+}
+
+func printCommands() {
+	fmt.Println("Commands:")
+	for _, cmd := range commandList {
+		fmt.Printf("\t%s: %s\n", cmd, helpTable[cmd].OLD)
+	}
+
+	fmt.Println("Use help command (e.g. help list) to read more detailed help messages.")
+}
+
+func help(args []string) error {
+	if len(args) == 0 {
+		printCommands()
+		return nil
+	}
+
+	cmd, ok := helpTable[args[0]]
+	if !ok {
+		return errors.New("command not found")
+	}
+
+	fmt.Printf("%s: %s\n\tArguments: %s\n%s\n\n",
+		args[0], cmd.OLD, cmd.Args, cmd.Desc)
+
+	return nil
+}

--- a/cmd/secretscli/secretscli.go
+++ b/cmd/secretscli/secretscli.go
@@ -154,6 +154,12 @@ func main() {
 	scryptInteractive := flag.Bool("i", false, "use scrypt interactive")
 	flag.Parse()
 
+	if defaultTimeout > maxTimeout {
+		fmt.Fprintf(os.Stderr, "[!] timeout is too long (max is %s).\n",
+			maxTimeout)
+		os.Exit(1)
+	}
+
 	session.Scrypt = secret.ScryptStandard
 	if *scryptInteractive {
 		session.Scrypt = secret.ScryptInteractive

--- a/cmd/secretscli/secretscli.go
+++ b/cmd/secretscli/secretscli.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kisom/cryptutils/common/secret"
+	"github.com/kisom/cryptutils/common/store"
+	"github.com/kisom/cryptutils/common/util"
+)
+
+var (
+	defaultTimeout = 5 * time.Minute
+	maxTimeout     = 12 * time.Hour
+)
+
+func readCommands(storeName string, input chan string, proceed chan bool) {
+	// Catch the case where the input channel is closed.
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("readCommands: %v", err)
+		}
+	}()
+
+	prompt := fmt.Sprintf("%s command> ", storeName)
+	for {
+		line, err := util.ReadLine(prompt)
+		if err != nil {
+			if err == io.EOF {
+				close(input)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "[!] %v", err)
+		}
+
+		if line == "" {
+			continue
+		}
+
+		input <- line
+		_, ok := <-proceed
+		if !ok {
+			fmt.Println("done")
+			return
+		}
+	}
+}
+
+func processCommands(line string, proceed chan bool) {
+	args := strings.Fields(line)
+	if len(args) == 0 {
+		proceed <- true
+		return
+	}
+
+	cmd := args[0]
+	args = args[1:]
+
+	f, ok := dispatch[cmd]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "[!] %s is not a valid command.\n", cmd)
+	} else {
+		err := f(args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[!] command failed: %v\n", err)
+		}
+	}
+
+	proceed <- true
+}
+
+func inputLoop(storeName string) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("inputLoop error: %v", err)
+		}
+	}()
+	input := make(chan string, 0)
+	proceed := make(chan bool, 0)
+
+	go readCommands(storeName, input, proceed)
+	var stop bool
+
+	for {
+		select {
+		case line, ok := <-input:
+			if !ok || line == "quit" {
+				stop = true
+				break
+			}
+			processCommands(line, proceed)
+		case <-time.After(defaultTimeout):
+			fmt.Println("\n\n[+] Locking store and exiting.")
+			close(proceed)
+			stop = true
+			break
+		}
+
+		if stop {
+			break
+		}
+	}
+}
+
+var session struct {
+	Store  *store.SecretStore
+	Path   string
+	Scrypt secret.ScryptMode
+	Dirty  bool
+	Locked bool
+}
+
+func writeStore() bool {
+	if !session.Dirty {
+		return true
+	}
+
+	fmt.Printf("[+] storing secret store...\n")
+	fileData, ok := store.MarshalSecretStore(session.Store, session.Scrypt)
+	if !ok {
+		return false
+	}
+
+	err := util.WriteFile(fileData, session.Path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] failed to write store to %s:\n",
+			err)
+		fmt.Fprintf(os.Stderr, "\t%v\n", err)
+		return false
+	}
+
+	session.Dirty = false
+	return true
+}
+
+func shutdown() {
+	if !writeStore() {
+		fmt.Fprintln(os.Stderr, "*** WARNING: store was NOT written to disk***")
+	}
+	session.Store.Zero()
+}
+
+func main() {
+	baseFile := filepath.Join(os.Getenv("HOME"), ".secrets.db")
+	flag.StringVar(&session.Path, "f", baseFile, "path to password store")
+	flag.DurationVar(&defaultTimeout, "t", defaultTimeout, "`timeout`")
+	scryptInteractive := flag.Bool("i", false, "use scrypt interactive")
+	flag.Parse()
+
+	session.Scrypt = secret.ScryptStandard
+	if *scryptInteractive {
+		session.Scrypt = secret.ScryptInteractive
+	}
+
+	prompt := fmt.Sprintf("Passphrase to unlock %s: ", session.Path)
+	passphrase, err := util.PassPrompt(prompt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %v\n", err)
+		os.Exit(1)
+	}
+
+	fileData, err := ioutil.ReadFile(session.Path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %v\n", err)
+		os.Exit(1)
+	}
+
+	var ok bool
+	session.Store, ok = store.UnmarshalSecretStore(fileData, passphrase,
+		session.Scrypt)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "[!] failed to unlocked store.\n")
+		os.Exit(1)
+	}
+	defer shutdown()
+
+	inputLoop(session.Path)
+}


### PR DESCRIPTION
```
~/src/github.com/kisom/cryptutils/cmd/secretscli
(0) <straka:kyle> $ secrets -f secrets.db -i -init 
Secrets passphrase> 
creating store...
~/src/github.com/kisom/cryptutils/cmd/secretscli
(0) <straka:kyle> $ secretscli -f secrets.db -i 
Passphrase to unlock secrets.db: 
secrets.db command> list
Key store: 0 keys
secrets.db command> store mail db
[+] Storing secret for mail
New password: 
[+] Storing secret for db
New password: 
secrets.db command> wmeta db
Enter metadata; use an empty line to indicate that you are done.
key = value: host = db.local
key = value: user = db-user
key = value: name = blatdb 
key = value: 
secrets.db command> wmeta db 
Enter metadata; use an empty line to indicate that you are done.
key = value: name = blat-db
Note: replacing previous value of 'blatdb'
key = value: 
secrets.db command> store db
[+] Storing secret for db
db exists. Overwrite secret (y/n)? n
Not overwriting.
secrets.db command> store db
[+] Storing secret for db
db exists. Overwrite secret (y/n)? y
New password: 
secrets.db command> [+] storing secret store...
~/src/github.com/kisom/cryptutils/cmd/secretscli
(0) <straka:kyle> $ 
```
